### PR TITLE
Move steed to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "pre-commit": "^1.1.2",
     "snazzy": "^5.0.0",
     "standard": "^8.5.0",
-    "steed": "^1.1.3",
     "tap": "^8.0.0"
   },
   "dependencies": {
@@ -45,6 +44,7 @@
     "pump": "^1.0.1",
     "qlobber": "^0.7.0",
     "readable-stream": "^2.2.1",
-    "upring": "^0.14.4"
+    "upring": "^0.14.4",
+    "steed": "^1.1.3"
   }
 }


### PR DESCRIPTION
The steed dependency are listed under devDependencies but are actually used in the module. Since its defined under devDependencies it will fail when this module are installed through npm.

This moves steed from devDependencies to dependencies.